### PR TITLE
Rename apply to update

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ branchtree checkout
 If you've made commits to a non-leaf branch, run this to propagate changes forward through the tree with merges and rebases:
 
 ```
-$ branchtree apply
+$ branchtree update
 ```
 
 To see the full usage, run:

--- a/lib/branchtree.rb
+++ b/lib/branchtree.rb
@@ -6,7 +6,7 @@ module Branchtree
     command_classes = {
       "show" => Branchtree::Commands::Show,
       "checkout" => Branchtree::Commands::Checkout,
-      "apply" => Branchtree::Commands::Apply,
+      "update" => Branchtree::Commands::Update,
     }
 
     command_name = argv.shift || "show"
@@ -53,4 +53,4 @@ require "branchtree/situation"
 require "branchtree/commands/common"
 require "branchtree/commands/show"
 require "branchtree/commands/checkout"
-require "branchtree/commands/apply"
+require "branchtree/commands/update"

--- a/lib/branchtree/commands/update.rb
+++ b/lib/branchtree/commands/update.rb
@@ -2,7 +2,7 @@ require "branchtree/commands/common"
 
 module Branchtree
   module Commands
-    class Apply < Common
+    class Update < Common
       include Branchtree::Context
 
       usage do


### PR DESCRIPTION
I keep mistyping `apply` as `update`. So, let's just rename it.