### PR TITLE
Include upstream ahead/behind in show output

### DIFF
--- a/lib/branchtree/branch.rb
+++ b/lib/branchtree/branch.rb
@@ -113,7 +113,7 @@ module Branchtree
         # Idenfity if we have an upstream
         upstream_ref, upstream_behind, upstream_ahead = "", 0, 0
         upstream_result = @branch.cmd.run!(
-          "git", "rev-parse", "--symbolic-full-name", "#{@branch.full_ref}@{u}",
+          "git", "rev-parse", "--symbolic-full-name", "#{@branch.name}@{u}",
         )
         if upstream_result.success?
           upstream_ref = upstream_result.out.chomp

--- a/lib/branchtree/commands/show.rb
+++ b/lib/branchtree/commands/show.rb
@@ -36,10 +36,16 @@ module Branchtree
             line << " (branch missing)"
           else
             if branch.info.behind_parent > 0
-              line << " - #{branch.info.behind_parent} commits behind parent"
+              line << " - #{pluralize(branch.info.behind_parent, "commit")} behind parent"
             end
             if branch.info.ahead_of_upstream > 0
-              line << " - #{branch.info.ahead_of_upstream} unpushed commits"
+              if branch.info.behind_upstream > 0
+                line << " - diverged from upstream (#{branch.info.ahead_of_upstream}/#{branch.info.behind_upstream})"
+              else
+                line << " - #{pluralize(branch.info.ahead_of_upstream, "unpushed commit")}"
+              end
+            elsif branch.info.behind_upstream > 0
+              line << " - #{pluralize(branch.info.behind_upstream, "commit")} behind upstream"
             end
           end
 

--- a/spec/branchtree/branch_spec.rb
+++ b/spec/branchtree/branch_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Branch do
         .with("git", "rev-list", "--left-right", "--count", "refs/heads/parent-ref...refs/heads/the-ref")
         .and_return(double(out: "2\t5\n"))
       allow(Context.cmd).to receive(:run!)
-        .with("git", "rev-parse", "--symbolic-full-name", "refs/heads/the-ref@{u}")
+        .with("git", "rev-parse", "--symbolic-full-name", "the-ref@{u}")
         .and_return(double(success?: false))
       
       branch.info.populate
@@ -104,7 +104,7 @@ RSpec.describe Branch do
         .with("git", "rev-list", "--left-right", "--count", "refs/heads/parent-ref...refs/heads/the-ref")
         .and_return(double(out: "0\t3\n"))
       allow(Context.cmd).to receive(:run!)
-        .with("git", "rev-parse", "--symbolic-full-name", "refs/heads/the-ref@{u}")
+        .with("git", "rev-parse", "--symbolic-full-name", "the-ref@{u}")
         .and_return(double(success?: true, out: "refs/remotes/origin/the-ref\n"))
       allow(Context.cmd).to receive(:run)
         .with("git", "rev-list", "--left-right", "--count", "refs/remotes/origin/the-ref...refs/heads/the-ref")


### PR DESCRIPTION
When running `branchtree show`, display the number of commits each branch is ahead or behind its upstream.