### PR TITLE
Handle branches with invalid parents more gracefully

### DIFF
--- a/lib/branchtree/branch.rb
+++ b/lib/branchtree/branch.rb
@@ -15,7 +15,7 @@ module Branchtree
       end
     end
 
-    attr_reader :name, :children
+    attr_reader :name, :parent, :children
     attr_accessor :info
 
     def initialize(name, parent, rebase)
@@ -104,11 +104,14 @@ module Branchtree
           return @branch.info = InvalidInfo.new(@branch)
         end
 
-        # Count ahead-behind from parent
-        ahead_behind_parent = @branch.cmd.run(
-          "git", "rev-list", "--left-right", "--count", "refs/heads/#{@branch.parent_branch_name}...#{@branch.full_ref}",
-        ).out.chomp
-        parent_behind, parent_ahead = ahead_behind_parent.split(/\t/, 2).map(&:to_i)
+        parent_behind, parent_ahead = 0, 0
+        if @branch.parent.info.valid?
+          # Count ahead-behind from parent
+          ahead_behind_parent = @branch.cmd.run(
+            "git", "rev-list", "--left-right", "--count", "refs/heads/#{@branch.parent_branch_name}...#{@branch.full_ref}",
+          ).out.chomp
+          parent_behind, parent_ahead = ahead_behind_parent.split(/\t/, 2).map(&:to_i)
+        end
 
         # Idenfity if we have an upstream
         upstream_ref, upstream_behind, upstream_ahead = "", 0, 0

--- a/spec/branchtree/branch_spec.rb
+++ b/spec/branchtree/branch_spec.rb
@@ -75,6 +75,25 @@ RSpec.describe Branch do
       expect(branch.info.behind_upstream).to eq(0)
     end
 
+    it "detects when its parent branch ref is not a valid branch name" do
+      allow(Context.cmd).to receive(:run!)
+        .with("git", "rev-parse", "--verify", "--quiet", "refs/heads/the-ref")
+        .and_return(double(success?: true))
+      allow(Context.cmd).to receive(:run!)
+        .with("git", "rev-parse", "--symbolic-full-name", "the-ref@{u}")
+        .and_return(double(success?: false))
+      allow(branch.parent.info).to receive(:valid?).and_return(false)
+
+      branch.info.populate
+      expect(branch.info).not_to be_empty
+      expect(branch.info).to be_valid
+      expect(branch.info.ahead_of_parent).to eq(0)
+      expect(branch.info.behind_parent).to eq(0)
+      expect(branch.info).not_to have_upstream
+      expect(branch.info.ahead_of_upstream).to eq(0)
+      expect(branch.info.behind_upstream).to eq(0)
+    end
+
     it "identifies the number of commits ahead and behind its parent" do
       allow(Context.cmd).to receive(:run!)
         .with("git", "rev-parse", "--verify", "--quiet", "refs/heads/the-ref")


### PR DESCRIPTION
Prevents this stack when running `branchtree status` with missing branches:

```
Traceback (most recent call last):
	14: from /Users/smashwilson/.rbenv/versions/2.7.1/bin/branchtree:23:in `<main>'
	13: from /Users/smashwilson/.rbenv/versions/2.7.1/bin/branchtree:23:in `load'
	12: from /Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/branchtree-0.1.0/exe/branchtree:5:in `<top (required)>'
	11: from /Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/branchtree-0.1.0/lib/branchtree.rb:27:in `execute'
	10: from /Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/branchtree-0.1.0/lib/branchtree/commands/show.rb:18:in `execute'
	 9: from /Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/branchtree-0.1.0/lib/branchtree/tree.rb:29:in `depth_first'
	 8: from /Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/branchtree-0.1.0/lib/branchtree/tree.rb:49:in `depth_first_from'
	 7: from /Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/branchtree-0.1.0/lib/branchtree/tree.rb:49:in `each'
	 6: from /Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/branchtree-0.1.0/lib/branchtree/tree.rb:51:in `block in depth_first_from'
	 5: from /Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/branchtree-0.1.0/lib/branchtree/tree.rb:49:in `depth_first_from'
	 4: from /Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/branchtree-0.1.0/lib/branchtree/tree.rb:49:in `each'
	 3: from /Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/branchtree-0.1.0/lib/branchtree/tree.rb:50:in `block in depth_first_from'
	 2: from /Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/branchtree-0.1.0/lib/branchtree/commands/show.rb:20:in `block in execute'
	 1: from /Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/branchtree-0.1.0/lib/branchtree/branch.rb:108:in `populate'
/Users/smashwilson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/tty-command-0.10.1/lib/tty/command.rb:106:in `run': Running `git rev-list --left-right --count refs/heads/xxxx...refs/heads/yyy` failed with (TTY::Command::ExitError)
  exit status: 128
  stdout: Nothing written
  stderr: fatal: ambiguous argument 'refs/heads/xxx...refs/heads/yyy': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
```